### PR TITLE
Fix php version require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.1|^8.0",
     "symfony/polyfill": "^1.27",
     "symfony/var-dumper": "4.*",
     "smarty/smarty": "^4.3"


### PR DESCRIPTION
before this fix, composer cant install/update on php 8.0+:
Root composer.json requires php ^7.1 but your php version (8.1.13) does not satisfy that requirement.